### PR TITLE
Implement frontend grouping for Facebook ad metrics

### DIFF
--- a/header.php
+++ b/header.php
@@ -18,6 +18,7 @@ require_once __DIR__ . "/backend/controllers/DashboardController.php";
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="/inventech-solution/assets/js/fetch-metrics-from-db.js" defer></script>
+    <script src="/inventech-solution/assets/js/metrics.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script><!-- Alpine.js (for x-data, x-show, @click) -->
     <link rel="stylesheet" href="https://cdn.hugeicons.com/font/hgi-stroke-rounded.css" />
     <style>


### PR DESCRIPTION
## Summary
- load metrics.js globally
- add client-side grouping of ads
- compute metrics using metrics.js after grouping
- log raw API data, grouped ads, and processed metrics

## Testing
- `npm test` *(fails: could not find package.json)*